### PR TITLE
Loosen bounds on base for GHC 8.8 compatibility.

### DIFF
--- a/fused-syntax.cabal
+++ b/fused-syntax.cabal
@@ -53,6 +53,6 @@ library
   other-modules:
     Example.Lam
   build-depends:
-      base          ^>=4.12.0.0
+      base           >= 4.12 && < 4.14
     , fused-effects ^>= 0.5
     , transformers  ^>= 0.5.6


### PR DESCRIPTION
Once this is applied, it compiles without incident on 8.8.1.