### PR TITLE
Higher-order traversal

### DIFF
--- a/fused-syntax.cabal
+++ b/fused-syntax.cabal
@@ -48,6 +48,7 @@ library
     Syntax.Sum
     Syntax.Term
     Syntax.Trans.Scope
+    Syntax.Traversable
     Syntax.Var
     Syntax.Vec
   other-modules:

--- a/fused-syntax.cabal
+++ b/fused-syntax.cabal
@@ -39,6 +39,7 @@ library
   exposed-modules:
     Syntax.Fin
     Syntax.Fix
+    Syntax.Foldable
     Syntax.Functor
     Syntax.Module
     Syntax.Nat

--- a/src/Example/Lam.hs
+++ b/src/Example/Lam.hs
@@ -9,6 +9,7 @@ import Control.Effect.Carrier
 import GHC.Generics (Generic1)
 import Syntax.Module
 import Syntax.Scope
+import Syntax.Traversable
 
 data Lam t a
   = Abs (Scope () t a)
@@ -36,3 +37,8 @@ lam v b = send (Abs (abstract1 v b))
 f $$ a = send (f :$ a)
 
 infixl 9 $$
+
+instance HTraversable Lam where
+  htraverse f = \case
+    Abs b  -> Abs <$> htraverse f b
+    g :$ a -> (:$) <$> f g <*> f a

--- a/src/Example/Lam.hs
+++ b/src/Example/Lam.hs
@@ -24,6 +24,7 @@ deriving instance (Ord  a, forall a . Eq   a => Eq   (f a)
 deriving instance (Show a, forall a . Show a => Show (f a))          => Show (Lam f a)
 
 instance HFunctor Lam
+instance HTraversable Lam
 
 instance RightModule Lam where
   Abs b  >>=* f = Abs (b >>=* f)
@@ -37,8 +38,3 @@ lam v b = send (Abs (abstract1 v b))
 f $$ a = send (f :$ a)
 
 infixl 9 $$
-
-instance HTraversable Lam where
-  htraverse f = \case
-    Abs b  -> Abs <$> htraverse f b
-    g :$ a -> (:$) <$> f g <*> f a

--- a/src/Example/Lam.hs
+++ b/src/Example/Lam.hs
@@ -5,8 +5,10 @@ module Example.Lam
 , ($$)
 ) where
 
+import Control.Applicative ((<|>))
 import Control.Effect.Carrier
 import GHC.Generics (Generic1)
+import Syntax.Foldable
 import Syntax.Module
 import Syntax.Scope
 import Syntax.Traversable
@@ -25,6 +27,10 @@ deriving instance (Show a, forall a . Show a => Show (f a))          => Show (La
 
 instance HFunctor Lam
 instance HTraversable Lam
+instance HFoldable Lam where
+  hfoldMap f = \case
+    Abs b  -> hfoldMap f b
+    g :$ a -> f g <|> f a
 
 instance RightModule Lam where
   Abs b  >>=* f = Abs (b >>=* f)

--- a/src/Example/Lam.hs
+++ b/src/Example/Lam.hs
@@ -5,7 +5,6 @@ module Example.Lam
 , ($$)
 ) where
 
-import Control.Applicative ((<|>))
 import Control.Effect.Carrier
 import GHC.Generics (Generic1)
 import Syntax.Foldable
@@ -25,12 +24,9 @@ deriving instance (Ord  a, forall a . Eq   a => Eq   (f a)
                          , forall a . Ord  a => Ord  (f a), Monad f) => Ord  (Lam f a)
 deriving instance (Show a, forall a . Show a => Show (f a))          => Show (Lam f a)
 
+instance HFoldable Lam
 instance HFunctor Lam
 instance HTraversable Lam
-instance HFoldable Lam where
-  hfoldMap f = \case
-    Abs b  -> hfoldMap f b
-    g :$ a -> f g <|> f a
 
 instance RightModule Lam where
   Abs b  >>=* f = Abs (b >>=* f)

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -5,6 +5,7 @@ module Syntax.Foldable
 ) where
 
 import Control.Applicative
+import Data.Monoid (Alt(..))
 import GHC.Generics
 import qualified Syntax.Sum as Sum
 
@@ -36,3 +37,6 @@ instance GHFoldable g Par1 where
 
 instance (GHFoldable g l, GHFoldable g r) => GHFoldable g (l :*: r) where
   ghfoldMap f (l :*: r) = ghfoldMap f l <|> ghfoldMap f r
+
+instance (Traversable f, GHFoldable g sig) => GHFoldable g (f :.: sig) where
+  ghfoldMap f = getAlt . foldMap (Alt . ghfoldMap f) . unComp1

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, TypeOperators #-}
+{-# LANGUAGE EmptyCase, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, TypeOperators #-}
 module Syntax.Foldable
 ( HFoldable(..)
 , GHFoldable(..)
 ) where
 
 import Control.Applicative
+import GHC.Generics
 import qualified Syntax.Sum as Sum
 
 class (forall g . Foldable g => Foldable (sig g))
@@ -20,3 +21,6 @@ instance (HFoldable l, HFoldable r) => HFoldable (l Sum.:+: r) where
 
 class GHFoldable g rep where
   ghfoldMap :: (Alternative m, Monad m, Foldable g) => (forall x . g x -> m x) -> rep a -> m a
+
+instance GHFoldable g V1 where
+  ghfoldMap _ = \case {}

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -30,3 +30,6 @@ instance GHFoldable g U1 where
 
 instance GHFoldable g (K1 R r) where
   ghfoldMap _ _ = empty
+
+instance GHFoldable g Par1 where
+  ghfoldMap _ _ = empty

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -1,0 +1,2 @@
+module Syntax.Foldable
+() where

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -48,3 +48,6 @@ instance (GHFoldable g l, GHFoldable g r) => GHFoldable g (l :+: r) where
 
 instance GHFoldable g f => GHFoldable g (M1 i c f) where
   ghfoldMap f = ghfoldMap f . unM1
+
+instance GHFoldable g (Rec1 g) where
+  ghfoldMap f = f . unRec1

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -1,2 +1,13 @@
+{-# LANGUAGE QuantifiedConstraints, RankNTypes #-}
 module Syntax.Foldable
-() where
+( HFoldable(..)
+) where
+
+import Control.Applicative
+
+class (forall g . Foldable g => Foldable (sig g))
+   => HFoldable sig where
+  hfoldMap
+    :: (Alternative m, Monad m, Foldable g)
+    => (forall a . g a -> m a)
+    -> (sig g a -> m a)

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE EmptyCase, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, TypeOperators #-}
 module Syntax.Foldable
 ( HFoldable(..)
 , GHFoldable(..)
@@ -15,6 +15,11 @@ class (forall g . Foldable g => Foldable (sig g))
     :: (Alternative m, Monad m, Foldable g)
     => (forall a . g a -> m a)
     -> (sig g a -> m a)
+  default hfoldMap
+    :: (Alternative m, Monad m, Foldable g, Generic1 (sig g), GHFoldable g (Rep1 (sig g)))
+    => (forall a . g a -> m a)
+    -> (sig g a -> m a)
+  hfoldMap f = ghfoldMap f . from1
 
 instance (HFoldable l, HFoldable r) => HFoldable (l Sum.:+: r) where
   hfoldMap f = Sum.unSum (hfoldMap f) (hfoldMap f)

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -33,3 +33,6 @@ instance GHFoldable g (K1 R r) where
 
 instance GHFoldable g Par1 where
   ghfoldMap _ _ = empty
+
+instance (GHFoldable g l, GHFoldable g r) => GHFoldable g (l :*: r) where
+  ghfoldMap f (l :*: r) = ghfoldMap f l <|> ghfoldMap f r

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE QuantifiedConstraints, RankNTypes, TypeOperators #-}
+{-# LANGUAGE MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, TypeOperators #-}
 module Syntax.Foldable
 ( HFoldable(..)
+, GHFoldable(..)
 ) where
 
 import Control.Applicative
@@ -15,3 +16,7 @@ class (forall g . Foldable g => Foldable (sig g))
 
 instance (HFoldable l, HFoldable r) => HFoldable (l Sum.:+: r) where
   hfoldMap f = Sum.unSum (hfoldMap f) (hfoldMap f)
+
+
+class GHFoldable g rep where
+  ghfoldMap :: (Alternative m, Monad m, Foldable g) => (forall x . g x -> m x) -> rep a -> m a

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -45,3 +45,6 @@ instance (GHFoldable g l, GHFoldable g r) => GHFoldable g (l :+: r) where
   ghfoldMap f = \case
     L1 l -> ghfoldMap f l
     R1 r -> ghfoldMap f r
+
+instance GHFoldable g f => GHFoldable g (M1 i c f) where
+  ghfoldMap f = ghfoldMap f . unM1

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -24,3 +24,6 @@ class GHFoldable g rep where
 
 instance GHFoldable g V1 where
   ghfoldMap _ = \case {}
+
+instance GHFoldable g U1 where
+  ghfoldMap _ _ = empty

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE QuantifiedConstraints, RankNTypes #-}
+{-# LANGUAGE QuantifiedConstraints, RankNTypes, TypeOperators #-}
 module Syntax.Foldable
 ( HFoldable(..)
 ) where
 
 import Control.Applicative
+import qualified Syntax.Sum as Sum
 
 class (forall g . Foldable g => Foldable (sig g))
    => HFoldable sig where
@@ -11,3 +12,6 @@ class (forall g . Foldable g => Foldable (sig g))
     :: (Alternative m, Monad m, Foldable g)
     => (forall a . g a -> m a)
     -> (sig g a -> m a)
+
+instance (HFoldable l, HFoldable r) => HFoldable (l Sum.:+: r) where
+  hfoldMap f = Sum.unSum (hfoldMap f) (hfoldMap f)

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -40,3 +40,8 @@ instance (GHFoldable g l, GHFoldable g r) => GHFoldable g (l :*: r) where
 
 instance (Traversable f, GHFoldable g sig) => GHFoldable g (f :.: sig) where
   ghfoldMap f = getAlt . foldMap (Alt . ghfoldMap f) . unComp1
+
+instance (GHFoldable g l, GHFoldable g r) => GHFoldable g (l :+: r) where
+  ghfoldMap f = \case
+    L1 l -> ghfoldMap f l
+    R1 r -> ghfoldMap f r

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -51,3 +51,6 @@ instance GHFoldable g f => GHFoldable g (M1 i c f) where
 
 instance GHFoldable g (Rec1 g) where
   ghfoldMap f = f . unRec1
+
+instance HFoldable sig => GHFoldable g (Rec1 (sig g)) where
+  ghfoldMap f = hfoldMap f . unRec1

--- a/src/Syntax/Foldable.hs
+++ b/src/Syntax/Foldable.hs
@@ -27,3 +27,6 @@ instance GHFoldable g V1 where
 
 instance GHFoldable g U1 where
   ghfoldMap _ _ = empty
+
+instance GHFoldable g (K1 R r) where
+  ghfoldMap _ _ = empty

--- a/src/Syntax/Scope.hs
+++ b/src/Syntax/Scope.hs
@@ -22,8 +22,10 @@ import Control.Monad ((<=<), guard)
 import Control.Monad.Trans.Class
 import Data.Bifunctor (first)
 import Data.Function (on)
+import Data.Monoid (Alt(..))
 import GHC.Generics (Generic, Generic1)
 import Syntax.Fin as Fin
+import Syntax.Foldable
 import Syntax.Functor
 import Syntax.Module
 import Syntax.Traversable
@@ -34,6 +36,9 @@ newtype Scope a f b = Scope (f (Var a (f b)))
 
 unScope :: Scope a f b -> f (Var a (f b))
 unScope (Scope s) = s
+
+instance HFoldable (Scope a) where
+  hfoldMap f = getAlt . foldMap (foldMap (Alt . f)) . unScope
 
 instance HFunctor (Scope a) where
   hmap f = Scope . f . fmap (fmap f) . unScope

--- a/src/Syntax/Scope.hs
+++ b/src/Syntax/Scope.hs
@@ -26,6 +26,7 @@ import GHC.Generics (Generic, Generic1)
 import Syntax.Fin as Fin
 import Syntax.Functor
 import Syntax.Module
+import Syntax.Traversable
 import Syntax.Var
 
 newtype Scope a f b = Scope (f (Var a (f b)))
@@ -36,6 +37,9 @@ unScope (Scope s) = s
 
 instance HFunctor (Scope a) where
   hmap f = Scope . f . fmap (fmap f) . unScope
+
+instance HTraversable (Scope a) where
+  htraverse f = fmap Scope . f <=< traverse (traverse f) . unScope
 
 instance (Eq  a, Eq  b, forall a . Eq  a => Eq  (f a), Monad f) => Eq  (Scope a f b) where
   (==) = (==) `on` fromScope

--- a/src/Syntax/Term.hs
+++ b/src/Syntax/Term.hs
@@ -6,6 +6,7 @@ module Syntax.Term
 , prjTerm
 , iter
 , cata
+, cataM
   -- * Pretty-printing
 , foldTerm
 ) where
@@ -17,6 +18,7 @@ import Syntax.Fin
 import Syntax.Functor
 import Syntax.Module
 import Syntax.Sum
+import Syntax.Traversable
 import Syntax.Var
 import Syntax.Vec
 
@@ -96,6 +98,20 @@ cata var alg = go where
   go = \case
     Var v -> var v
     Alg t -> alg (hmap go t)
+
+cataM
+  :: forall sig m f a
+  .  ( HTraversable sig
+     , Monad m
+     )
+  => (forall x . x -> m (f x))
+  -> (forall x . sig f x -> m (f x))
+  -> (Term sig a -> m (f a))
+cataM var alg = go where
+  go :: forall a . Term sig a -> m (f a)
+  go = \case
+    Var v -> var v
+    Alg t -> alg =<< htraverse go t
 
 
 foldTerm

--- a/src/Syntax/Term.hs
+++ b/src/Syntax/Term.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Syntax.Term
 ( Term(..)
 , hoistTerm
@@ -7,6 +7,7 @@ module Syntax.Term
 , iter
 , cata
 , cataM
+, handle
   -- * Pretty-printing
 , foldTerm
 ) where
@@ -112,6 +113,18 @@ cataM var alg = go where
   go = \case
     Var v -> var v
     Alg t -> alg =<< htraverse go t
+
+handle
+  :: forall syn sig m a
+  .  ( HTraversable sig
+     , HTraversable syn
+     , Monad m
+     )
+  => (forall   x . x       -> m (Term sig x))
+  -> (forall t x . syn t x -> m (Term sig x))
+  -> Term (syn :+: sig) a
+  -> m (Term sig a)
+handle var alg = cataM var (unSum alg (fmap Alg . htraverse pure))
 
 
 foldTerm

--- a/src/Syntax/Term.hs
+++ b/src/Syntax/Term.hs
@@ -124,7 +124,7 @@ handle
   -> (forall t x . syn t x -> m (Term sig x))
   -> Term (syn :+: sig) a
   -> m (Term sig a)
-handle var alg = cataM var (unSum alg (fmap Alg . htraverse pure))
+handle var alg = cataM var (unSum alg (pure . Alg))
 
 
 foldTerm

--- a/src/Syntax/Trans/Scope.hs
+++ b/src/Syntax/Trans/Scope.hs
@@ -22,8 +22,10 @@ import Control.Monad ((<=<), guard)
 import Control.Monad.Trans.Class
 import Data.Bifunctor (first)
 import Data.Function (on)
+import Data.Monoid (Alt(..))
 import GHC.Generics (Generic, Generic1)
 import Syntax.Fin as Fin
+import Syntax.Foldable
 import Syntax.Functor
 import Syntax.Module
 import Syntax.Traversable
@@ -35,6 +37,9 @@ newtype ScopeT a t f b = ScopeT (t f (Var a (f b)))
 
 unScopeT :: ScopeT a t f b -> t f (Var a (f b))
 unScopeT (ScopeT s) = s
+
+instance HFoldable t => HFoldable (ScopeT a t) where
+  hfoldMap f = getAlt . foldMap (Alt . f) <=< hfoldMap f . unScopeT
 
 instance (HFunctor t, forall g . Functor g => Functor (t g)) => HFunctor (ScopeT a t) where
   hmap f = ScopeT . hmap f . fmap (fmap f) . unScopeT

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -5,7 +5,7 @@ module Syntax.Traversable
 ) where
 
 import Syntax.Functor
-import Syntax.Sum
+import qualified Syntax.Sum as Sum
 
 class ( HFunctor sig
       , forall g . Foldable g    => Foldable    (sig g)
@@ -18,8 +18,8 @@ class ( HFunctor sig
     => (forall a . g a -> f (h a))
     -> (sig g a -> f (sig h a))
 
-instance (HTraversable l, HTraversable r) => HTraversable (l :+: r) where
-  htraverse f = unSum (fmap L . htraverse f) (fmap R . htraverse f)
+instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r) where
+  htraverse f = Sum.unSum (fmap Sum.L . htraverse f) (fmap Sum.R . htraverse f)
 
 
 class GHTraversable g h rep rep' where

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -47,3 +47,6 @@ instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g
 
 instance GHTraversable g g' f f' => GHTraversable g g' (M1 i c f) (M1 i c f') where
   ghtraverse f = fmap M1 . ghtraverse f . unM1
+
+instance GHTraversable g g' (Rec1 g) (Rec1 g') where
+  ghtraverse f = fmap Rec1 . f . unRec1

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE RankNTypes, QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes, QuantifiedConstraints, TypeOperators #-}
 module Syntax.Traversable
 ( HTraversable(..)
 ) where
 
 import Syntax.Functor
+import Syntax.Sum
 
 class ( HFunctor sig
       , forall g . Foldable g    => Foldable    (sig g)
@@ -12,3 +13,6 @@ class ( HFunctor sig
       )
    => HTraversable sig where
   htraverse :: (Monad f, Traversable g) => (forall a . g a -> f (h a)) -> sig g a -> f (sig h a)
+
+instance (HTraversable l, HTraversable r) => HTraversable (l :+: r) where
+  htraverse f = unSum (fmap L . htraverse f) (fmap R . htraverse f)

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
 module Syntax.Traversable
 ( HTraversable(..)
 , GHTraversable(..)
@@ -32,7 +32,7 @@ class GHTraversable g h rep rep' where
   ghtraverse :: (Monad f, Traversable g) => (forall x . g x -> f (h x)) -> rep a -> f (rep' a)
 
 instance GHTraversable g h V1 V1 where
-  ghtraverse _ v = case v of {}
+  ghtraverse _ = \case {}
 
 instance GHTraversable g h U1 U1 where
   ghtraverse _ = pure

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -24,8 +24,7 @@ class ( HFunctor sig
     -> (sig g a -> f (sig h a))
   htraverse f = fmap to1 . ghtraverse f . from1
 
-instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r) where
-  htraverse f = Sum.unSum (fmap Sum.L . htraverse f) (fmap Sum.R . htraverse f)
+instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r)
 
 
 class GHTraversable g g' rep rep' where

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,2 +1,14 @@
+{-# LANGUAGE RankNTypes, QuantifiedConstraints #-}
 module Syntax.Traversable
-() where
+( HTraversable(..)
+) where
+
+import Syntax.Functor
+
+class ( HFunctor sig
+      , forall g . Foldable g    => Foldable    (sig g)
+      , forall g . Functor  g    => Functor     (sig g)
+      , forall g . Traversable g => Traversable (sig g)
+      )
+   => HTraversable sig where
+  htraverse :: (Monad f, Traversable g) => (forall a . g a -> f (h a)) -> sig g a -> f (sig h a)

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -39,3 +39,8 @@ instance GHTraversable g g' U1 U1 where
 
 instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :*: r) (l' :*: r') where
   ghtraverse f (l :*: r) = (:*:) <$> ghtraverse f l <*> ghtraverse f r
+
+instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :+: r) (l' :+: r') where
+  ghtraverse f = \case
+    L1 l -> L1 <$> ghtraverse f l
+    R1 r -> R1 <$> ghtraverse f r

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
 module Syntax.Traversable
 ( HTraversable(..)
 , GHTraversable(..)
@@ -30,6 +30,9 @@ instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r) where
 
 class GHTraversable g h rep rep' where
   ghtraverse :: (Monad f, Traversable g) => (forall x . g x -> f (h x)) -> rep a -> f (rep' a)
+
+instance GHTraversable g h V1 V1 where
+  ghtraverse _ v = case v of {}
 
 instance GHTraversable g h U1 U1 where
   ghtraverse _ = pure

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,0 +1,2 @@
+module Syntax.Traversable
+() where

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -39,6 +39,9 @@ instance GHTraversable g g' U1 U1 where
 instance GHTraversable g g' (K1 R r) (K1 R r) where
   ghtraverse _ = pure
 
+instance GHTraversable g g' Par1 Par1 where
+  ghtraverse _ = pure
+
 instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :*: r) (l' :*: r') where
   ghtraverse f (l :*: r) = (:*:) <$> ghtraverse f l <*> ghtraverse f r
 

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -50,3 +50,6 @@ instance GHTraversable g g' f f' => GHTraversable g g' (M1 i c f) (M1 i c f') wh
 
 instance GHTraversable g g' (Rec1 g) (Rec1 g') where
   ghtraverse f = fmap Rec1 . f . unRec1
+
+instance HTraversable sig => GHTraversable g g' (Rec1 (sig g)) (Rec1 (sig g')) where
+  ghtraverse f = fmap Rec1 . htraverse f . unRec1

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -44,3 +44,6 @@ instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g
   ghtraverse f = \case
     L1 l -> L1 <$> ghtraverse f l
     R1 r -> R1 <$> ghtraverse f r
+
+instance GHTraversable g g' f f' => GHTraversable g g' (M1 i c f) (M1 i c f') where
+  ghtraverse f = fmap M1 . ghtraverse f . unM1

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -5,11 +5,12 @@ module Syntax.Traversable
 ) where
 
 import GHC.Generics
+import Syntax.Foldable
 import Syntax.Functor
 import qualified Syntax.Sum as Sum
 
-class ( HFunctor sig
-      , forall g . Foldable g    => Foldable    (sig g)
+class ( HFoldable sig
+      , HFunctor sig
       , forall g . Functor  g    => Functor     (sig g)
       , forall g . Traversable g => Traversable (sig g)
       )

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -45,6 +45,9 @@ instance GHTraversable g g' Par1 Par1 where
 instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :*: r) (l' :*: r') where
   ghtraverse f (l :*: r) = (:*:) <$> ghtraverse f l <*> ghtraverse f r
 
+instance (Traversable f, GHTraversable g g' sig sig') => GHTraversable g g' (f :.: sig) (f :.: sig') where
+  ghtraverse f = fmap Comp1 . traverse (ghtraverse f) . unComp1
+
 instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :+: r) (l' :+: r') where
   ghtraverse f = \case
     L1 l -> L1 <$> ghtraverse f l

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -13,7 +13,10 @@ class ( HFunctor sig
       , forall g . Traversable g => Traversable (sig g)
       )
    => HTraversable sig where
-  htraverse :: (Monad f, Traversable g) => (forall a . g a -> f (h a)) -> sig g a -> f (sig h a)
+  htraverse
+    :: (Monad f, Traversable g)
+    => (forall a . g a -> f (h a))
+    -> (sig g a -> f (sig h a))
 
 instance (HTraversable l, HTraversable r) => HTraversable (l :+: r) where
   htraverse f = unSum (fmap L . htraverse f) (fmap R . htraverse f)

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -36,6 +36,9 @@ instance GHTraversable g g' V1 V1 where
 instance GHTraversable g g' U1 U1 where
   ghtraverse _ = pure
 
+instance GHTraversable g g' (K1 R r) (K1 R r) where
+  ghtraverse _ = pure
+
 instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :*: r) (l' :*: r') where
   ghtraverse f (l :*: r) = (:*:) <$> ghtraverse f l <*> ghtraverse f r
 

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, FlexibleContexts, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
 module Syntax.Traversable
 ( HTraversable(..)
 , GHTraversable(..)
@@ -30,3 +30,6 @@ instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r) where
 
 class GHTraversable g h rep rep' where
   ghtraverse :: (Monad f, Traversable g) => (forall x . g x -> f (h x)) -> rep a -> f (rep' a)
+
+instance GHTraversable g h U1 U1 where
+  ghtraverse _ = pure

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE RankNTypes, QuantifiedConstraints, TypeOperators #-}
+{-# LANGUAGE MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
 module Syntax.Traversable
 ( HTraversable(..)
+, GHTraversable(..)
 ) where
 
 import Syntax.Functor
@@ -16,3 +17,7 @@ class ( HFunctor sig
 
 instance (HTraversable l, HTraversable r) => HTraversable (l :+: r) where
   htraverse f = unSum (fmap L . htraverse f) (fmap R . htraverse f)
+
+
+class GHTraversable g h rep rep' where
+  ghtraverse :: (Monad f, Traversable g) => (forall x . g x -> f (h x)) -> rep a -> f (rep' a)

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -36,3 +36,6 @@ instance GHTraversable g g' V1 V1 where
 
 instance GHTraversable g g' U1 U1 where
   ghtraverse _ = pure
+
+instance (GHTraversable g g' l l', GHTraversable g g' r r') => GHTraversable g g' (l :*: r) (l' :*: r') where
+  ghtraverse f (l :*: r) = (:*:) <$> ghtraverse f l <*> ghtraverse f r

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -28,11 +28,11 @@ instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r) where
   htraverse f = Sum.unSum (fmap Sum.L . htraverse f) (fmap Sum.R . htraverse f)
 
 
-class GHTraversable g h rep rep' where
-  ghtraverse :: (Monad f, Traversable g) => (forall x . g x -> f (h x)) -> rep a -> f (rep' a)
+class GHTraversable g g' rep rep' where
+  ghtraverse :: (Monad f, Traversable g) => (forall x . g x -> f (g' x)) -> rep a -> f (rep' a)
 
-instance GHTraversable g h V1 V1 where
+instance GHTraversable g g' V1 V1 where
   ghtraverse _ = \case {}
 
-instance GHTraversable g h U1 U1 where
+instance GHTraversable g g' U1 U1 where
   ghtraverse _ = pure

--- a/src/Syntax/Traversable.hs
+++ b/src/Syntax/Traversable.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, FlexibleContexts, MultiParamTypeClasses, RankNTypes, QuantifiedConstraints, TypeOperators #-}
 module Syntax.Traversable
 ( HTraversable(..)
 , GHTraversable(..)
 ) where
 
+import GHC.Generics
 import Syntax.Functor
 import qualified Syntax.Sum as Sum
 
@@ -17,6 +18,11 @@ class ( HFunctor sig
     :: (Monad f, Traversable g)
     => (forall a . g a -> f (h a))
     -> (sig g a -> f (sig h a))
+  default htraverse
+    :: (Monad f, Traversable g, Generic1 (sig g), Generic1 (sig h), GHTraversable g h (Rep1 (sig g)) (Rep1 (sig h)))
+    => (forall a . g a -> f (h a))
+    -> (sig g a -> f (sig h a))
+  htraverse f = fmap to1 . ghtraverse f . from1
 
 instance (HTraversable l, HTraversable r) => HTraversable (l Sum.:+: r) where
   htraverse f = Sum.unSum (fmap Sum.L . htraverse f) (fmap Sum.R . htraverse f)


### PR DESCRIPTION
This PR adds an `HTraversable` class, definable by syntax, and a couple of operations on `Term`s using it.

TODO:

- [x] Generic derivation of `HTraversable` instances.
- [x] ~~Definition of `hmap` using `htraverse` (à la `fmapDefault`).~~ **Edit:** `hmap` doesn’t have a `Traversable` constraint on the higher-order positions, so this won’t work.
- [x] ~~`DerivingVia`-compatible `newtype` for the above.~~
- [x] `HFoldable`?